### PR TITLE
chore: add CI workflow, SECURITY.md, and update word count limits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 ### Format & Content
 
 - [ ] SKILL.md follows [SKILL-TEMPLATE.md](SKILL-TEMPLATE.md) format
-- [ ] SKILL.md is under 2,000 words (detailed content in supporting files)
+- [ ] SKILL.md is under 2,500 words (target 2,000; detailed content in supporting files)
 - [ ] `description` field is optimised for agent discovery (keywords in first 50 words)
 - [ ] "What This Skill Cannot Do" section is honest and specific
 - [ ] Confidence levels (HIGH/MEDIUM/LOW) included in output format

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,132 @@
+name: Validate Skills
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check SKILL.md frontmatter
+        run: |
+          failed=0
+          required_fields="name description jurisdiction personas version"
+
+          for skill_file in skills/*/SKILL.md; do
+            skill_name=$(basename "$(dirname "$skill_file")")
+
+            # Extract frontmatter block (content between first two --- delimiters)
+            frontmatter=$(awk '/^---$/{c++; next} c==1{print} c>=2{exit}' "$skill_file")
+
+            if [ -z "$frontmatter" ]; then
+              echo "::error file=$skill_file::Missing YAML frontmatter"
+              failed=1
+              continue
+            fi
+
+            for field in $required_fields; do
+              if ! echo "$frontmatter" | grep -q "^${field}:"; then
+                echo "::error file=$skill_file::Missing required frontmatter field: $field"
+                failed=1
+              fi
+            done
+          done
+
+          exit $failed
+
+      - name: Check SKILL.md word count
+        run: |
+          failed=0
+          max_words=2500
+
+          for skill_file in skills/*/SKILL.md; do
+            skill_name=$(basename "$(dirname "$skill_file")")
+
+            # Count words in body only (after second --- delimiter)
+            body=$(awk '/^---$/{c++; next} c>=2{print}' "$skill_file")
+            word_count=$(echo "$body" | wc -w | tr -d ' ')
+
+            if [ "$word_count" -gt "$max_words" ]; then
+              echo "::error file=$skill_file::Word count $word_count exceeds hard limit of $max_words"
+              failed=1
+            elif [ "$word_count" -gt 2000 ]; then
+              echo "::warning file=$skill_file::Word count $word_count exceeds 2,000-word target (hard limit: $max_words)"
+            fi
+          done
+
+          exit $failed
+
+      - name: Check required sections
+        run: |
+          failed=0
+          required_sections=(
+            "When to Use"
+            "What This Skill Cannot Do"
+            "Prerequisites"
+            "Process"
+            "Output Format"
+            "Jurisdiction Notes"
+            "References"
+            "Changelog"
+          )
+
+          for skill_file in skills/*/SKILL.md; do
+            skill_name=$(basename "$(dirname "$skill_file")")
+
+            for section in "${required_sections[@]}"; do
+              if ! grep -q "^## .*${section}" "$skill_file"; then
+                echo "::error file=$skill_file::Missing required section: ## $section"
+                failed=1
+              fi
+            done
+          done
+
+          exit $failed
+
+      - name: Check README consistency
+        run: |
+          failed=0
+
+          for skill_dir in skills/*/; do
+            skill_name=$(basename "$skill_dir")
+
+            if ! grep -q "skills/${skill_name}/" README.md; then
+              echo "::error::Skill '$skill_name' exists in skills/ but has no entry in README.md index table"
+              failed=1
+            fi
+          done
+
+          exit $failed
+
+      - name: PII pattern scan (non-blocking)
+        run: |
+          # Scan example files for patterns that look like real PII
+          # Uses ::warning annotations — does NOT fail the job
+
+          for example_file in skills/*/examples/*.md; do
+            [ -f "$example_file" ] || continue
+
+            # SSN pattern (excluding known safe prefixes)
+            if grep -Pn '\d{3}-\d{2}-\d{4}' "$example_file" | grep -Pv '(000-00-|123-45-|555-)' > /dev/null 2>&1; then
+              echo "::warning file=$example_file::Possible SSN pattern detected — verify this is synthetic data"
+            fi
+
+            # Email addresses on non-example domains
+            if grep -Pon '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$example_file" | grep -Pvi '(example\.com|test\.com|example\.org|localhost|acme\.com)' > /dev/null 2>&1; then
+              echo "::warning file=$example_file::Non-example email domain detected — verify this is synthetic data"
+            fi
+
+            # Phone numbers with real area codes (excluding 555 prefix)
+            if grep -Pn '\b\d{3}[-.]?\d{3}[-.]?\d{4}\b' "$example_file" | grep -Pv '(555[-.]?\d{3}[-.]?\d{4}|000[-.]?000)' > /dev/null 2>&1; then
+              echo "::warning file=$example_file::Possible real phone number detected — verify this is synthetic data"
+            fi
+          done
+
+          # Always pass — these are warnings only
+          exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Every skill must follow [SKILL-TEMPLATE.md](SKILL-TEMPLATE.md). Key rules:
 
 - **YAML frontmatter** with all required fields (name, description, jurisdiction, personas, version)
 - **All sections present**: When to Use, What This Skill Cannot Do, Prerequisites, Process, Output Format, Jurisdiction Notes, References, Changelog
-- **SKILL.md word budget: under 2,000 words.** Move detailed checklists, tables, and reference material to supporting files in the skill's subdirectory.
+- **SKILL.md word budget: target under 2,000 words, hard limit 2,500.** Move detailed checklists, tables, and reference material to supporting files in the skill's subdirectory.
 
 ### Writing Style
 
@@ -159,7 +159,7 @@ Organise supporting files in the skill's subdirectory:
 
 ```
 skills/[skill-name]/
-├── SKILL.md              # Primary skill file (under 2,000 words)
+├── SKILL.md              # Primary skill file (target 2,000 words, hard limit 2,500)
 ├── checklists/           # Reference checklists the skill uses
 ├── templates/            # Output templates
 └── examples/             # Worked examples (input + expected output)
@@ -179,7 +179,7 @@ Every PR must satisfy this checklist (also in the PR template):
 - [ ] *(Optional)* Adversarial resistance results included (run `./eval/run-adversarial.sh --skill <name>`)
 - [ ] Regulatory sources cited with specific articles/sections and verification dates
 - [ ] Jurisdiction notes included (or skill is explicitly principle-based)
-- [ ] SKILL.md is under 2,000 words (detailed content in supporting files)
+- [ ] SKILL.md is under 2,500 words (target 2,000; detailed content in supporting files)
 - [ ] README.md skill index table updated
 - [ ] No real personal data in examples (use synthetic or anonymised data only)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security & Regulatory Accuracy Policy
+
+## Scope
+
+This policy covers **regulatory accuracy issues** where incorrect guidance could lead to non-compliance or user harm. Examples:
+
+- Wrong article or section citation (e.g., referencing GDPR Art. 30 when Art. 35 is correct)
+- Outdated regulation reference (e.g., citing a repealed provision)
+- Guidance that contradicts the cited source text
+- Missing critical exception or limitation that changes the meaning of a requirement
+
+## How to Report
+
+**Preferred:** Use GitHub's **"Report a vulnerability"** button (Security tab → "Report a vulnerability"). This provides a tracked, private disclosure channel.
+
+**Fallback:** Email [support@healthy-tension.com](mailto:support@healthy-tension.com) with the subject line "Regulatory Accuracy Issue".
+
+Please include:
+- The skill name and version
+- The specific citation or guidance that is incorrect
+- The authoritative source showing the correct information
+- The potential impact (what could go wrong if someone follows the incorrect guidance)
+
+## Response Time
+
+- **Acknowledgment**: Within 72 hours
+- **Fix or public advisory**: Within 30 days for confirmed issues
+
+## What Is NOT a Security or Regulatory Issue
+
+Use regular [GitHub issues](https://github.com/lolokauf/healthy-tension-privacy-skills/issues) for:
+
+- Formatting, typos, or style preferences
+- Disagreements about severity ratings
+- Feature requests or new skill proposals
+- General questions about privacy frameworks
+
+## Credit
+
+Reporters are credited in the fix commit and CHANGELOG unless they prefer anonymity. Let us know your preference when reporting.
+
+## Important Note
+
+This library does not provide legal advice. All skills are technical assessment frameworks requiring human review. However, regulatory accuracy is critical — incorrect citations can misdirect compliance efforts, which is why we treat accuracy issues with the urgency of security vulnerabilities.


### PR DESCRIPTION
## Summary

- Add lightweight CI workflow (`.github/workflows/validate-skills.yml`) that validates SKILL.md format on PRs to main
- Add `SECURITY.md` for regulatory accuracy disclosure via GitHub Private Vulnerability Reporting
- Update word count guidance: target 2,000 words, hard limit 2,500 (2 existing skills exceed 2,000)

## CI Checks

The workflow validates:
1. **Frontmatter** — 5 required YAML fields (name, description, jurisdiction, personas, version)
2. **Word count** — body text under 2,500 (warns above 2,000)
3. **Required sections** — 8 mandatory `##` headings
4. **README consistency** — every `skills/*/` directory has an index table entry
5. **PII scan** — non-blocking warnings for patterns that look like real PII in examples

## Checklist

- [x] CI workflow tested locally against all 5 existing skills (all pass)
- [x] Word count limits updated in CONTRIBUTING.md and PR template
- [x] SECURITY.md covers scope, reporting channels, response times, and credit

🤖 Generated with [Claude Code](https://claude.com/claude-code)